### PR TITLE
Learn more & Download buttons on header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,9 +67,9 @@ theme = "hugo-creative-theme"
 		#subtitle   = "The easy to install Linux distribution with a friendly feel that comes with the latest and greatest apps at your fingertips."
 		subtitle = "The Linux distribution that is easy to install, stable and always up-to-date."
 
-		callToAction = "Learn more about Manjaro"
+		callToAction = "Learn more"
 		callToActionUrl = "#about"
-		learnMore = "or download directly"
+		learnMore = "Download"
 		learnMoreUrl = "#downloads"
 
 	[params.posthome]

--- a/config.toml
+++ b/config.toml
@@ -67,10 +67,10 @@ theme = "hugo-creative-theme"
 		#subtitle   = "The easy to install Linux distribution with a friendly feel that comes with the latest and greatest apps at your fingertips."
 		subtitle = "The Linux distribution that is easy to install, stable and always up-to-date."
 
-		callToAction = "Learn more"
-		callToActionUrl = "#about"
-		learnMore = "Download"
-		learnMoreUrl = "#downloads"
+		learnMore = "Learn more"
+		learnMoreUrl = "#about"
+		download = "Download"
+		downloadUrl = "#downloads"
 
 	[params.posthome]
 		callToAction = "Download now"

--- a/config.toml
+++ b/config.toml
@@ -61,7 +61,7 @@ theme = "hugo-creative-theme"
 	# Hero section*
 	[params.hero]
 		# To change the background of the hero section, replace the 'header.jpg' at './static/img' with your own.
-		image = "manjaro-logo.png	"
+		image = "manjaro-logo.png"
 		slogan     = "manjaro linux"
 		subslogan = "Fast & stable."
 		#subtitle   = "The easy to install Linux distribution with a friendly feel that comes with the latest and greatest apps at your fingertips."

--- a/public/index.html
+++ b/public/index.html
@@ -105,7 +105,7 @@
             <h2>Fast &amp; stable.</h2>
             <hr>
             <p>The Linux distribution that is easy to install, stable and always up-to-date.</p>
-            
+
             <a href="https://manjaro.github.io/homepage/public/features" style="margin-left: 15px; min-width: 152px;" class="btn btn-primary btn-xl page-scroll">Learn more about Manjaro</a>
             <p style="margin-top: 10px;"><a href="https://manjaro.github.io/homepage/public/download" style="margin-left: 15px; min-width: 152px;" class="btn-hero page-scroll">or download directly</a></p>
         </div>

--- a/themes/hugo-creative-theme/layouts/partials/hero.html
+++ b/themes/hugo-creative-theme/layouts/partials/hero.html
@@ -1,15 +1,18 @@
 {{ "<!-- HEADER -->" | safeHTML }}
 <header class="index-header">
-    <div class="header-content">
-        <div class="header-content-inner">
-            <p><img src="img/manjaro-logo.svg" /></p>
-            <h1>{{ with .Site.Params.hero.slogan }}{{ . | markdownify  }}{{ end }}</h1>
-            <h2>{{ with .Site.Params.hero.subslogan }}{{ . | markdownify  }}{{ end }}</h2>
-            <hr>
-            <p>{{ with .Site.Params.hero.subtitle }}{{ . | markdownify }}{{ end }}</p>
-            <!--<a href="#about" class="btn btn-default btn-xl page-scroll">{{ with .Site.Params.hero.buttonText }}{{ . }}{{ end }}</a>-->
-            <a href="{{ .Site.BaseURL }}features" style="margin-left: 15px; min-width: 152px;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.callToAction }}{{ . }}{{ end }}</a>
-            <p style="margin-top: 10px;"><a href="{{ .Site.BaseURL }}download" style="margin-left: 15px; min-width: 152px;" class="btn-hero page-scroll">{{ with .Site.Params.hero.learnMore }}{{ . }}{{ end }}</a></p>
+  <div class="header-content">
+    <div class="header-content-inner">
+      <p><img src="img/manjaro-logo.svg" /></p>
+      <h1>{{ with .Site.Params.hero.slogan }}{{ . | markdownify  }}{{ end }}</h1>
+      <h2>{{ with .Site.Params.hero.subslogan }}{{ . | markdownify  }}{{ end }}</h2>
+      <hr>
+      <p>{{ with .Site.Params.hero.subtitle }}{{ . | markdownify }}{{ end }}</p>
+      <div class="row">
+        <div class="col-md-offset-3 col-md-6">
+          <a href="{{ .Site.BaseURL }}features" style="margin-left: 15px; max-width: 50%;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.callToAction }}{{ . }}{{ end }}</a>
+          <a href="{{ .Site.BaseURL }}download" style="margin-left: 15px; max-width: 50%;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.learnMore }}{{ . }}{{ end }}</a>
         </div>
+      </div>
     </div>
+  </div>
 </header>

--- a/themes/hugo-creative-theme/layouts/partials/hero.html
+++ b/themes/hugo-creative-theme/layouts/partials/hero.html
@@ -9,8 +9,8 @@
       <p>{{ with .Site.Params.hero.subtitle }}{{ . | markdownify }}{{ end }}</p>
       <div class="row">
         <div class="col-md-offset-3 col-md-6">
-          <a href="{{ .Site.BaseURL }}features" style="margin-left: 15px; max-width: 50%;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.callToAction }}{{ . }}{{ end }}</a>
-          <a href="{{ .Site.BaseURL }}download" style="margin-left: 15px; max-width: 50%;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.learnMore }}{{ . }}{{ end }}</a>
+          <a href="{{ .Site.BaseURL }}features" style="margin-left: 15px; max-width: 50%;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.learnMore }}{{ . }}{{ end }}</a>
+          <a href="{{ .Site.BaseURL }}download" style="margin-left: 15px; max-width: 50%;" class="btn btn-primary btn-xl page-scroll">{{ with .Site.Params.hero.download }}{{ . }}{{ end }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Reason

### What the current header links look like:
![current header links](http://i.imgur.com/AYvND4fl.png "current header links")

I opened a issue for this here: #12 
The current background image(and possibly future ones) make reading text hard. We can fix this by reducing text over the image, and making any possible text into buttons. You can see this issue with the description text here.
![hard to read text](http://imgur.com/YwyaQMql.png)


### Purposed change for header links:
![purposed header links](http://imgur.com/CaWNpOzl.png "purposed header links")

This is easier to read(as opposed to the "OR DOWNLOAD DIRECTLY" option we have now).With this we can  also give user a nice big Download button, the less user have to read the better.

### Small fix
I also ran into and fixed issue #13